### PR TITLE
Adding to the family state machine and states

### DIFF
--- a/Assets/Scripts/BananaTrap.cs
+++ b/Assets/Scripts/BananaTrap.cs
@@ -9,56 +9,58 @@ public abstract class Trap : MonoBehaviour
   public abstract void ActivateTrap(GameObject enemy);
 }
 
-// public class BananaTrap : Trap
-// {
-//     [SerializeField] private AudioSource audioSource;
+public class BananaTrap : Trap
+{
+    [SerializeField] private AudioSource audioSource;
 
-//     private void Awake()
-//     {
-//         // Initialize the audioSource component
-//         audioSource = GetComponent<AudioSource>();
-//     }
+    private void Awake()
+    {
+        // Initialize the audioSource component
+        audioSource = GetComponent<AudioSource>();
+    }
 
-//     private void OnTriggerEnter(Collider other)
-//     {
-//       if (other.CompareTag("Henry"))
-//       {
-//           print("Henry triggered the trap");
-//           PlayTrapSound();
-//           ActivateTrap(other.gameObject);
-//           //PlayTrapSound();  // Play the sound effect
-//           Destroy(gameObject, 2f);  // Add a 0.5-second delay before destroying
-//       }
-//     }
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.CompareTag("Henry"))
+        {
+            print("Henry triggered the trap");
+            PlayTrapSound();
+            ActivateTrap(other.gameObject);
+            //PlayTrapSound();  // Play the sound effect
+            Destroy(gameObject, 2f);  // Add a 0.5-second delay before destroying
+        }
+    }
 
 
-//     public override void ActivateTrap(GameObject enemy)
-//     {
-//         FamilyMember familyMemberScript = enemy.GetComponent<FamilyMember>();
-//         if (familyMemberScript != null)
-//         {
-//             FamilyStateMachine state_machine = enemy.gameObject.GetComponent<FamilyMember>().stateMachine;
-//             state_machine.freeze_state.effect_duration = effectDuration;
-//             state_machine.freeze_state.is_trap_slip = true;
-//             state_machine.ChangeState(state_machine.freeze_state);
-//         }
-//     }
 
-//     // Method to play the trap sound
-//     private void PlayTrapSound()
-//     {
-//         if (audioSource != null)
-//         {
-//             Debug.Log("Playing trap sound effect");  // Debug message to check if it's being triggered
-//             audioSource.Play();  // Play the assigned sound
-//         }
-//         else
-//         {
-//             Debug.LogWarning("AudioSource is not assigned on the trap prefab.");
-//         }
-//     }
-// }
+     public override void ActivateTrap(GameObject enemy)
+     {
+         FamilyMember familyMemberScript = enemy.GetComponent<FamilyMember>();
+         if (familyMemberScript != null)
+         {
+             FamilyStateMachine state_machine = enemy.gameObject.GetComponent<FamilyMember>().stateMachine;
+             state_machine.freeze_state.effect_duration = effectDuration;
+             state_machine.freeze_state.is_trap_slip = true;
+             state_machine.ChangeState(state_machine.freeze_state);
+         }
+     }
 
+     // Method to play the trap sound
+     private void PlayTrapSound()
+     {
+         if (audioSource != null)
+         {
+             Debug.Log("Playing trap sound effect");  // Debug message to check if it's being triggered
+             audioSource.Play();  // Play the assigned sound
+         }
+         else
+         {
+             Debug.LogWarning("AudioSource is not assigned on the trap prefab.");
+         }
+     }
+ }
+
+/*
 public class BananaTrap : Trap
 {
   [SerializeField] private AudioClip slipSound;  // Reference to the slip sound clip
@@ -113,3 +115,4 @@ public class BananaTrap : Trap
     }
   }
 }
+*/

--- a/Assets/Scripts/CharacterScripts/PlayerScripts/StateMachines/Movement/States/PlayerMovementState.cs
+++ b/Assets/Scripts/CharacterScripts/PlayerScripts/StateMachines/Movement/States/PlayerMovementState.cs
@@ -17,7 +17,7 @@ namespace MaskedMischiefNamespace
 
 		public virtual void Enter()
 		{
-			//Debug.Log("Entering State: " + GetType().Name);
+			Debug.Log("Entering State: " + GetType().Name);
 			AddCallbacks();
 		}
 		public virtual void Exit()

--- a/Assets/Scripts/CharacterScripts/PlayerScripts/StateMachines/Movement/States/PlayerMovementState.cs
+++ b/Assets/Scripts/CharacterScripts/PlayerScripts/StateMachines/Movement/States/PlayerMovementState.cs
@@ -17,7 +17,7 @@ namespace MaskedMischiefNamespace
 
 		public virtual void Enter()
 		{
-			Debug.Log("Entering State: " + GetType().Name);
+			//Debug.Log("Entering State: " + GetType().Name);
 			AddCallbacks();
 		}
 		public virtual void Exit()

--- a/Assets/Scripts/FamilyMembers/FamilyMember.cs
+++ b/Assets/Scripts/FamilyMembers/FamilyMember.cs
@@ -133,6 +133,16 @@ public abstract class FamilyMember : MonoBehaviour
         }
     }
 
+    public void RespondToSound(DetectableSound sound)
+    {
+        stateMachine.search_state.search_location = sound.sound_position;
+        if(stateMachine.current_state == stateMachine.search_state || stateMachine.current_state == stateMachine.patrol_state)
+        {
+            stateMachine.ChangeState(stateMachine.search_state);
+        }
+        print("Hear Song");
+    }
+
     protected virtual Vector3[] getWaypointArray(string name, string type)
     {
         UnityEngine.Debug.Log("FamilyMember getWaypointArray type " + name + " " + type);

--- a/Assets/Scripts/FamilyMembers/FamilyMember.cs
+++ b/Assets/Scripts/FamilyMembers/FamilyMember.cs
@@ -29,7 +29,7 @@ public abstract class FamilyMember : MonoBehaviour
     [SerializeField] protected GameObject win_lose_controller;
 
 
-    protected FieldOfView fieldOfView;
+    public FieldOfView fieldOfView;
     [SerializeField] protected float viewRadius;
     [Range(0, 360)][SerializeField] protected float viewAngle = 120;
     [Range(0, 360)][SerializeField] protected float periferalAngle = 190;
@@ -41,7 +41,6 @@ public abstract class FamilyMember : MonoBehaviour
     public float patrolDuration = 10;
     public float secondsSinceSeenPlayer = 0;
     protected Coroutine timerCoroutine;
-    bool isTimerCoroutineRunning = false;
 
     public GameObject patrolPointOperator;
 
@@ -76,11 +75,6 @@ public abstract class FamilyMember : MonoBehaviour
         if (fieldOfView.canSeePlayer)
         {
             hasSeenPlayer = true;
-            if (isTimerCoroutineRunning)
-            {
-                isTimerCoroutineRunning = false;
-                StopCoroutine(timerCoroutine);
-            }
             player_last_seen_position = player.transform.position;
             SeesRaccoon();
         }
@@ -92,7 +86,7 @@ public abstract class FamilyMember : MonoBehaviour
                 stateMachine.ChangeState(stateMachine.search_state);
                 hasSeenPlayer = false;
                 // Go on Patrol, start timer with secondsSinceSeenPlayer
-                timerCoroutine = StartCoroutine(seePlayerTimer());
+                //timerCoroutine = StartCoroutine(seePlayerTimer());
             }
             else
             {
@@ -100,7 +94,7 @@ public abstract class FamilyMember : MonoBehaviour
             }
         }
     }
-
+    /*
     protected IEnumerator seePlayerTimer()
     {
         isTimerCoroutineRunning = true;
@@ -124,6 +118,7 @@ public abstract class FamilyMember : MonoBehaviour
         isTimerCoroutineRunning = false;
         secondsSinceSeenPlayer = 0;
     }
+    */
 
     protected virtual void SeesRaccoon()
     {

--- a/Assets/Scripts/FamilyMembers/FamilyMember.cs
+++ b/Assets/Scripts/FamilyMembers/FamilyMember.cs
@@ -42,6 +42,8 @@ public abstract class FamilyMember : MonoBehaviour
     public float secondsSinceSeenPlayer = 0;
     protected Coroutine timerCoroutine;
 
+    public bool is_charging = false;
+
     public GameObject patrolPointOperator;
 
     public Material MainColor, FreezeColor;
@@ -72,6 +74,11 @@ public abstract class FamilyMember : MonoBehaviour
 
     protected void CheckForRaccoon()
     {
+        if(is_charging)
+        {
+            return;
+        }
+
         if (fieldOfView.canSeePlayer)
         {
             hasSeenPlayer = true;

--- a/Assets/Scripts/FamilyMembers/FamilyStateMachine/EmilyActivatedState.cs
+++ b/Assets/Scripts/FamilyMembers/FamilyStateMachine/EmilyActivatedState.cs
@@ -50,6 +50,8 @@ public class EmilyActivatedState : FamilyBaseState
     {
         nav_mesh_member.ResetPath();
         charge_timer = 0;
+        member_animator.ResetTrigger("isWalking");
+        member_animator.SetTrigger("isIdle");
     }
 
     private void KeepInRange()
@@ -57,10 +59,14 @@ public class EmilyActivatedState : FamilyBaseState
 
         if (distance_to_player > follow_distance)
         {
+            member_animator.ResetTrigger("isIdle");
+            member_animator.SetTrigger("isWalking");
             nav_mesh_member.SetDestination(player.transform.position);
         }
         else
         {
+            member_animator.ResetTrigger("isWalking");
+            member_animator.SetTrigger("isIdle");
             nav_mesh_member.ResetPath();
         }
 

--- a/Assets/Scripts/FamilyMembers/FamilyStateMachine/EmilyChargeState.cs
+++ b/Assets/Scripts/FamilyMembers/FamilyStateMachine/EmilyChargeState.cs
@@ -12,6 +12,8 @@ public class EmilyChargeState : FamilyBaseState
 
     private float distance_to_player;
     private float charge_stop_distance = .5f;
+    private Vector3 charge_direction;
+    private bool was_frozen;
 
     private readonly EmilyController member;
     private Animator member_animator;
@@ -26,31 +28,52 @@ public class EmilyChargeState : FamilyBaseState
 
     public override void EnterState()
     {
+        member.is_charging = true;
         player = member.player;
         normal_speed = nav_mesh_member.speed;
-        charge_speed = normal_speed * 5;
-        nav_mesh_member.destination = player.transform.position;
+        charge_speed = normal_speed * 3;
+
+        nav_mesh_member.speed = charge_speed;
+        if(!was_frozen)
+        {
+            charge_direction = (player.transform.position - member.transform.position).normalized;
+        }
+        was_frozen = true;
+        nav_mesh_member.isStopped = true;
     }
 
     public override void UpdateState()
     {
-        nav_mesh_member.speed = charge_speed;
-        distance_to_player = Vector3.Distance(member.transform.position, player.transform.position);
-        if(nav_mesh_member.remainingDistance < charge_stop_distance)
+        nav_mesh_member.Move(charge_direction * charge_speed * Time.deltaTime);
+
+        RaycastHit hit;
+        Debug.DrawRay(member.transform.position + Vector3.up, charge_direction, Color.green, 1f);
+        if (Physics.Raycast(member.transform.position + Vector3.up, charge_direction, out hit, 1f))
         {
-            member.stateMachine.ChangeState(member.stateMachine.activated_state);
+            nav_mesh_member.velocity = Vector3.zero;
+            HandleCollision(hit.collider);  
         }
     }
+
+    private void HandleCollision(Collider collider)
+    {
+        member.stateMachine.ChangeState(member.stateMachine.activated_state);
+
+        if (collider.CompareTag("Player"))
+        {
+            player.GetComponent<LifeTracker>().LoseLife();
+        }
+
+        //Debug.Log("Emily collided with " + collider.gameObject.name);
+        member.is_charging = true;
+        was_frozen = false;
+    }
+
 
     public override void ExitState()
     {
         nav_mesh_member.velocity = Vector3.zero;
         nav_mesh_member.speed = normal_speed;
-        if (distance_to_player <= charge_stop_distance + .1f)
-        {
-            player.GetComponent<LifeTracker>().LoseLife();
-
-        }
         nav_mesh_member.ResetPath();
     }
 

--- a/Assets/Scripts/FamilyMembers/FamilyStateMachine/EmilyChargeState.cs
+++ b/Assets/Scripts/FamilyMembers/FamilyStateMachine/EmilyChargeState.cs
@@ -65,7 +65,7 @@ public class EmilyChargeState : FamilyBaseState
         }
 
         //Debug.Log("Emily collided with " + collider.gameObject.name);
-        member.is_charging = true;
+        member.is_charging = false;
         was_frozen = false;
     }
 

--- a/Assets/Scripts/FamilyMembers/FamilyStateMachine/EmilyChargeState.cs
+++ b/Assets/Scripts/FamilyMembers/FamilyStateMachine/EmilyChargeState.cs
@@ -29,6 +29,8 @@ public class EmilyChargeState : FamilyBaseState
     public override void EnterState()
     {
         member.is_charging = true;
+        member_animator.ResetTrigger("isIdle");
+        member_animator.SetTrigger("isWalking");
         player = member.player;
         normal_speed = nav_mesh_member.speed;
         charge_speed = normal_speed * 3;
@@ -47,7 +49,7 @@ public class EmilyChargeState : FamilyBaseState
         nav_mesh_member.Move(charge_direction * charge_speed * Time.deltaTime);
 
         RaycastHit hit;
-        Debug.DrawRay(member.transform.position + Vector3.up, charge_direction, Color.green, 1f);
+        //Debug.DrawRay(member.transform.position + Vector3.up, charge_direction, Color.green, 1f);
         if (Physics.Raycast(member.transform.position + Vector3.up, charge_direction, out hit, 1f))
         {
             nav_mesh_member.velocity = Vector3.zero;

--- a/Assets/Scripts/FamilyMembers/FamilyStateMachine/FamilyFreezeState.cs
+++ b/Assets/Scripts/FamilyMembers/FamilyStateMachine/FamilyFreezeState.cs
@@ -102,19 +102,18 @@ public class FamilyFreezeState : FamilyBaseState
             member_animator.enabled = true; // Resume animations
 
             // Reset rotation and position
-            //member.transform.GetChild(0).rotation = Quaternion.Euler(0f, member.transform.rotation.eulerAngles.y, member.transform.rotation.eulerAngles.z);
-
-
-            nav_mesh_member.enabled = false; // Disable NavMeshAgent temporarily
+            member.transform.GetChild(0).rotation = Quaternion.Euler(0f, member.transform.rotation.eulerAngles.y, 0f); // Reset rotation
             member.transform.GetChild(0).position = pre_fall_position;
+
             member_animator.ResetTrigger("isFalling");
             member_animator.SetTrigger("isIdle");
 
             yield return new WaitForSeconds(0.1f); // Add a slight delay to ensure position update takes effect
             nav_mesh_member.enabled = true; // Re-enable NavMeshAgent
         }
-        
+
         member.stateMachine.ChangeState(member.stateMachine.previous_state);
     }
+
 
 }

--- a/Assets/Scripts/FamilyMembers/FamilyStateMachine/FamilyPatrolState.cs
+++ b/Assets/Scripts/FamilyMembers/FamilyStateMachine/FamilyPatrolState.cs
@@ -23,6 +23,7 @@ public class FamilyPatrolState : FamilyBaseState
     public override void EnterState()
     {
         member_animator.enabled = true;
+
         patrolCoroutine = member.StartCoroutine(Patrol(member.waypoint_array));
     }
 
@@ -51,6 +52,7 @@ public class FamilyPatrolState : FamilyBaseState
             {
                 member_animator.ResetTrigger("isWalking");
                 member_animator.SetTrigger("isIdle");
+                Debug.Log("idle");
 
                 waypoint_index = (waypoint_index + 1) % waypoints.Length;
                 waypoint_target = waypoints[waypoint_index];
@@ -59,20 +61,9 @@ public class FamilyPatrolState : FamilyBaseState
 
                 member_animator.ResetTrigger("isIdle");
                 member_animator.SetTrigger("isWalking");
+                Debug.Log("walking");
             }
             yield return null;
-        }
-    }
-
-    private void walkingTransition(bool walking)
-    {
-        if (walking)
-        {
-            member_animator.SetBool("isWalking", true);
-        }
-        else
-        {
-            member_animator.SetBool("isWalking", false);
         }
     }
 }

--- a/Assets/Scripts/FamilyMembers/FamilyStateMachine/FamilyPatrolState.cs
+++ b/Assets/Scripts/FamilyMembers/FamilyStateMachine/FamilyPatrolState.cs
@@ -52,7 +52,6 @@ public class FamilyPatrolState : FamilyBaseState
             {
                 member_animator.ResetTrigger("isWalking");
                 member_animator.SetTrigger("isIdle");
-                Debug.Log("idle");
 
                 waypoint_index = (waypoint_index + 1) % waypoints.Length;
                 waypoint_target = waypoints[waypoint_index];
@@ -61,7 +60,6 @@ public class FamilyPatrolState : FamilyBaseState
 
                 member_animator.ResetTrigger("isIdle");
                 member_animator.SetTrigger("isWalking");
-                Debug.Log("walking");
             }
             yield return null;
         }

--- a/Assets/Scripts/FamilyMembers/FamilyStateMachine/FamilySearchState.cs
+++ b/Assets/Scripts/FamilyMembers/FamilyStateMachine/FamilySearchState.cs
@@ -59,7 +59,6 @@ public class FamilySearchState : FamilyBaseState
         seconds_since_rotated = 0;
         reached_search_location = false;
 
-        // Add this to reset animations
         member_animator.ResetTrigger("isIdle");
         member_animator.ResetTrigger("isWalking");
     }

--- a/Assets/Scripts/FamilyMembers/FamilyStateMachine/FamilySearchState.cs
+++ b/Assets/Scripts/FamilyMembers/FamilyStateMachine/FamilySearchState.cs
@@ -9,7 +9,11 @@ public class FamilySearchState : FamilyBaseState
     private readonly FamilyMember member;
     private Animator member_animator;
     private NavMeshAgent nav_mesh_member;
+    
     public Vector3 search_location;
+    private float seconds_since_seen_player;
+    private float search_time = 5f;
+    private bool reached_search_location;
 
     public FamilySearchState(FamilyMember family_member, Animator animator, NavMeshAgent nav_mesh_agent)
     {
@@ -20,16 +24,43 @@ public class FamilySearchState : FamilyBaseState
 
     public override void EnterState()
     {
+        reached_search_location = false;
         nav_mesh_member.destination = search_location;
     }
 
     public override void UpdateState()
     {
-
+        if(reached_search_location)
+        {
+            SeePlayerTimer();
+        }
+        else
+        {
+            IsAtDestination();
+        }
     }
 
     public override void ExitState()
     {
         nav_mesh_member.ResetPath();
+        seconds_since_seen_player = 0;
+        reached_search_location = false;
+    }
+
+    protected void SeePlayerTimer()
+    {
+            seconds_since_seen_player += Time.deltaTime;
+            if (seconds_since_seen_player >= search_time)
+            {
+                member.stateMachine.ChangeState(member.stateMachine.patrol_state);
+            }
+    }
+
+    protected void IsAtDestination()
+    {
+        if (!nav_mesh_member.pathPending && nav_mesh_member.remainingDistance <= nav_mesh_member.stoppingDistance)
+        {
+            reached_search_location = true;
+        }
     }
 }

--- a/Assets/Scripts/FamilyMembers/FamilyStateMachine/FamilySearchState.cs
+++ b/Assets/Scripts/FamilyMembers/FamilyStateMachine/FamilySearchState.cs
@@ -11,8 +11,15 @@ public class FamilySearchState : FamilyBaseState
     private NavMeshAgent nav_mesh_member;
     
     public Vector3 search_location;
+
     private float seconds_since_seen_player;
-    private float search_time = 5f;
+    private float seconds_since_rotated;
+
+    private bool is_rotating;
+    private Quaternion target_rotation;
+
+    private float search_time = 10f;
+    private float rotation_time;
     private bool reached_search_location;
 
     public FamilySearchState(FamilyMember family_member, Animator animator, NavMeshAgent nav_mesh_agent)
@@ -25,7 +32,11 @@ public class FamilySearchState : FamilyBaseState
     public override void EnterState()
     {
         reached_search_location = false;
+        set_rotation_time();
+        is_rotating = false;
         nav_mesh_member.destination = search_location;
+        member_animator.ResetTrigger("isIdle");
+        member_animator.SetTrigger("isWalking");
     }
 
     public override void UpdateState()
@@ -33,6 +44,7 @@ public class FamilySearchState : FamilyBaseState
         if(reached_search_location)
         {
             SeePlayerTimer();
+            RotateRandomly();
         }
         else
         {
@@ -44,7 +56,12 @@ public class FamilySearchState : FamilyBaseState
     {
         nav_mesh_member.ResetPath();
         seconds_since_seen_player = 0;
+        seconds_since_rotated = 0;
         reached_search_location = false;
+
+        // Add this to reset animations
+        member_animator.ResetTrigger("isIdle");
+        member_animator.ResetTrigger("isWalking");
     }
 
     protected void SeePlayerTimer()
@@ -61,6 +78,38 @@ public class FamilySearchState : FamilyBaseState
         if (!nav_mesh_member.pathPending && nav_mesh_member.remainingDistance <= nav_mesh_member.stoppingDistance)
         {
             reached_search_location = true;
+            member_animator.ResetTrigger("isWalking");
+            member_animator.SetTrigger("isIdle");
         }
+    }
+
+    private void RotateRandomly()
+    {
+        if(is_rotating)
+        {
+            member.transform.rotation = Quaternion.Lerp(member.transform.rotation,target_rotation,Time.deltaTime * 2f);
+            if (Quaternion.Angle(member.transform.rotation, target_rotation) < 1f)
+            {
+                is_rotating = false;
+                set_rotation_time();
+            }
+        }
+        else
+        {
+            seconds_since_rotated += Time.deltaTime;
+            if (seconds_since_rotated >= rotation_time)
+            {
+                float random_angle = UnityEngine.Random.Range(0f, 360f);
+                target_rotation = Quaternion.Euler(0, random_angle, 0);
+
+                is_rotating = true;
+                seconds_since_rotated = 0;
+            }
+        }
+    }
+
+    private void set_rotation_time()
+    {
+        rotation_time = Random.Range(.2f, .5f);
     }
 }

--- a/Assets/Scripts/FamilyMembers/FamilyStateMachine/FamilyStateMachine.cs
+++ b/Assets/Scripts/FamilyMembers/FamilyStateMachine/FamilyStateMachine.cs
@@ -15,7 +15,6 @@ public class FamilyStateMachine
     public FamilyFreezeState freeze_state;
     public FamilySearchState search_state;
 
-    //private Dictionary<Type, List>
 
     public FamilyStateMachine(FamilyPatrolState patrol, FamilyBaseState activated, FamilyFreezeState freeze, FamilySearchState search)
     {
@@ -40,18 +39,6 @@ public class FamilyStateMachine
             current_state = state;
             Debug.Log("Changed to state: " + state);
             state.EnterState();
-        }
-    }
-
-    private class transition
-    {
-        public Func<bool> Condition { get; }
-        public FamilyBaseState To { get; }
-
-        public transition(FamilyBaseState to, Func<bool> condition)
-        {
-            To = to;
-            Condition = condition;
         }
     }
 }

--- a/Assets/Scripts/FamilyMembers/FamilyStateMachine/FamilyStateMachine.cs
+++ b/Assets/Scripts/FamilyMembers/FamilyStateMachine/FamilyStateMachine.cs
@@ -15,6 +15,8 @@ public class FamilyStateMachine
     public FamilyFreezeState freeze_state;
     public FamilySearchState search_state;
 
+    //private Dictionary<Type, List>
+
     public FamilyStateMachine(FamilyPatrolState patrol, FamilyBaseState activated, FamilyFreezeState freeze, FamilySearchState search)
     {
         patrol_state = patrol;
@@ -38,6 +40,18 @@ public class FamilyStateMachine
             current_state = state;
             Debug.Log("Changed to state: " + state);
             state.EnterState();
+        }
+    }
+
+    private class transition
+    {
+        public Func<bool> Condition { get; }
+        public FamilyBaseState To { get; }
+
+        public transition(FamilyBaseState to, Func<bool> condition)
+        {
+            To = to;
+            Condition = condition;
         }
     }
 }

--- a/Assets/Scripts/FamilyMembers/Henry/HenryController.cs
+++ b/Assets/Scripts/FamilyMembers/Henry/HenryController.cs
@@ -32,7 +32,6 @@ public class HenryController : FamilyMember
 
         stateMachine.current_state = patrol;
         stateMachine.current_state.EnterState();
-        //HenryStartInHouse();
     }
 
     private void collisionOccur_onRaccoonFirstTimeOnTrash(object sender, System.EventArgs e)

--- a/Assets/Scripts/Item Interaction Scripts/WashingMachineInteractable.cs
+++ b/Assets/Scripts/Item Interaction Scripts/WashingMachineInteractable.cs
@@ -4,14 +4,20 @@ using UnityEngine;
 
 public class WashingMachineInteractable : Interactable
 {
-    private AudioSource audioSource;
+    private AudioSource audio_source;
+    private float sound_range = 25f;
 
     protected override void Interact()
     {
-        audioSource = GetComponent<AudioSource>();
-        if (audioSource != null && !audioSource.isPlaying)
+        audio_source = GetComponent<AudioSource>();
+        if (audio_source == null || audio_source.isPlaying)
         {
-            audioSource.Play();
+            return;
         }
+
+        audio_source.Play();
+
+        var sound = new DetectableSound(transform.position, sound_range);
+        MakeSound.GetSoundListners(sound);
     }
 }

--- a/Assets/Scripts/Sounds.meta
+++ b/Assets/Scripts/Sounds.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6374944932aa556458f02b34c54689a7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Sounds/DetectableSound.cs
+++ b/Assets/Scripts/Sounds/DetectableSound.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+public class DetectableSound
+{
+    public readonly Vector3 sound_position;
+    public readonly float sound_range;
+
+    public DetectableSound(Vector3 position, float range)
+    {
+        sound_position = position;
+        sound_range = range;
+    }
+}

--- a/Assets/Scripts/Sounds/DetectableSound.cs.meta
+++ b/Assets/Scripts/Sounds/DetectableSound.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 022d759c9855eef41b8504b0babec4db
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Sounds/MakeSound.cs
+++ b/Assets/Scripts/Sounds/MakeSound.cs
@@ -1,0 +1,20 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MakeSound : MonoBehaviour
+{
+    private static LayerMask mask = LayerMask.GetMask("Default"); 
+    public static void GetSoundListners(DetectableSound sound)
+    {
+        Collider[] col = Physics.OverlapSphere(sound.sound_position, sound.sound_range, mask);
+
+        for (int i = 0; i < col.Length; i++)
+        {
+            if (col[i].TryGetComponent(out FamilyMember listner))
+            {
+                listner.RespondToSound(sound);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Sounds/MakeSound.cs.meta
+++ b/Assets/Scripts/Sounds/MakeSound.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b77a85ae304909044bbf35004a7879bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- see example of how to set this up in WashingMachineInteractable
--------------------------------------------------------------------
- a sound is used to store origin of sound and range
-Then it makes the noise in MakeSound
-MakeSound checks if any object in range has FamilyMember
-if collision has FamilyMember it calls RespondToSound in family Member
- This sets up proper requirements to transfer to a search state
-----------------------------------------------------------------------
- moved seePlayerTimer to search state so that search state can be more complex
- refactored seePlayerTimer to remove now unnecessary elements
- emily now charges past player and only stops when colliding with something
- when family member enters a patrol state they now will rotate
- emily can now go back to the search state after a charge
- emily's animation work for activated state
- emily's animation work for charging state